### PR TITLE
Renderer

### DIFF
--- a/src/lib.h
+++ b/src/lib.h
@@ -8,8 +8,11 @@
 #define ERR_MEM_ALLOC 0x01
 #define ERR_PARAM_NULL 0x02
 #define ERR_FILE_OPEN 0x04
+#define ERR_OBJECT_NULL 0x08
 
 #define LIB_ERR(msg, err) lib_error(__FILE__, __LINE__, msg, err)
+
+#define LEN(arr) ((int)(sizeof(arr) / sizeof(arr)[0]))
 
 /*
  * Function: lib_error

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -1,0 +1,49 @@
+#include "renderer.h"
+
+screen_t *screen_init(tilemap_t *tilemap)
+{
+    if (tilemap == NULL)
+        LIB_ERR("tilemap is null", ERR_PARAM_NULL);
+
+    screen_t *screen = (screen_t *)malloc(sizeof(screen_t));
+
+    if (screen == NULL)
+        LIB_ERR("Error allocating memory for screen", ERR_MEM_ALLOC);
+
+    screen->content = tilemap;
+
+    return screen;
+}
+
+void screen_free(screen_t *screen)
+{
+    if (screen == NULL)
+        return;
+
+    if (screen->content != NULL)
+    {
+        tilemap_free(screen->content);
+    }
+
+    free(screen);
+}
+
+void render(screen_t *screen)
+{
+    if (screen == NULL)
+        LIB_ERR("screen is null", ERR_PARAM_NULL);
+
+    if (screen->content == NULL)
+        LIB_ERR("screen data is null", ERR_OBJECT_NULL);
+
+    if (screen->content->rows <= 0 || screen->content->cols <= 0)
+        printf("\nrows: %d, cols: %d", screen->content->rows, screen->content->cols), exit(-1);
+
+    for (size_t i = 0; i < screen->content->rows; i++)
+    {
+        for (size_t j = 0; j < screen->content->cols; j++)
+        {
+            printf("%c", screen->content->data[i][j].sym);
+        }
+    }
+}

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -1,0 +1,40 @@
+#ifndef RENDERER_H_
+#define RENDERER_H_
+
+#include "./tiles.h"
+
+typedef struct screen
+{
+    tilemap_t *content;
+} screen_t;
+
+/*
+ * Function: screen_init
+ * ----------------------------
+ *   Initializes a new tilemap struct
+ *
+ *   tilemap: tilemap struct pointer that the screen knows what to display.
+ *
+ *   returns: screen struct pointer
+ */
+screen_t *screen_init(tilemap_t *tilemap);
+
+/*
+ * Function: screen_free
+ * ----------------------------
+ *   Frees the memory of a screen struct pointer.
+ * 
+ *   This functions also clears the screen data.
+ *
+ *   screen: screen struct pointer
+ */
+void screen_free(screen_t *screen);
+
+/*
+ * Function: render
+ * ----------------------------
+ *   Renders a screen (Only tilemap data works currently)
+ */
+void render(screen_t *screen);
+
+#endif

--- a/tests/test.c
+++ b/tests/test.c
@@ -1,4 +1,5 @@
 #include "../build/include/tiles.h"
+#include "../build/include/renderer.h"
 
 int main(int argc, char **argv)
 {
@@ -7,9 +8,11 @@ int main(int argc, char **argv)
         // create tilemap and load content from file
         tilemap_t *tiles = tilemap_initf(argv[1]);
 
-        tilemap_print(tiles);
+        screen_t *screen = screen_init(tiles);
 
-        tilemap_free(tiles);
+        render(screen);
+
+        screen_free(screen);
 
         return EXIT_SUCCESS;
     }


### PR DESCRIPTION
## Renderer System Prototype

### Important changes
- `tiles.c` All rendering methods are now removed and moved to `screen.c`.
- `screen.c` Contains all rendering methods to load & inject things to the tilemap.

### Why the change?
Tilemaps should be used to load "static" content, like a dungeon crawler map.
With the new renderer system I can directly inject stuff like player, enemies, loot without changing the tilemap itself.

**This also makes it easier to implement custom maps.**